### PR TITLE
유저별로 최신 기사 3개 불러오기

### DIFF
--- a/src/main/java/gyeongdan/article/controller/ArticleController.java
+++ b/src/main/java/gyeongdan/article/controller/ArticleController.java
@@ -42,8 +42,15 @@ public class ArticleController {
 
     // 최근 조회한 기사 3개 가져오기
     @GetMapping("/recent")
-    public ResponseEntity<?> getRecentViewedArticles() {
-        List<Article> recentViewedArticles = articleService.getRecentViewedArticles();
+    public ResponseEntity<?> getRecentViewedArticles(@RequestHeader @Nullable String accessToken) {
+        Optional<Long> userId = Optional.empty();
+        if (accessToken != null && !accessToken.isEmpty()) {
+            userId = jwtUtil.getUserId(jwtUtil.resolveToken(accessToken));
+        }
+        System.out.println("응애 : " + userId);
+
+        List<Article> recentViewedArticles = articleService.getRecentViewedArticles(userId.orElse(null));
+
         return ResponseEntity.ok(new CommonResponse<>(recentViewedArticles, "가장 최근에 조회한 게시글 3개 조회 성공", true));
     }
 }

--- a/src/main/java/gyeongdan/article/repository/ArticleViewHistoryJpaRepository.java
+++ b/src/main/java/gyeongdan/article/repository/ArticleViewHistoryJpaRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ArticleViewHistoryJpaRepository extends JpaRepository<ArticleViewHistory, Long> {
-    List<ArticleViewHistory> findTop100ByOrderByViewedAtDesc();
+    List<ArticleViewHistory> findTop100ByUserIdOrderByViewedAtDesc(Long userId);
 }

--- a/src/main/java/gyeongdan/article/service/ArticleService.java
+++ b/src/main/java/gyeongdan/article/service/ArticleService.java
@@ -78,8 +78,13 @@ public class ArticleService {
 
 
     // 최근 조회한 기사 3개 가져오는 메서드
-    public List<Article> getRecentViewedArticles() {
-        List<ArticleViewHistory> recentViewedHistories = articleViewHistoryJpaRepository.findTop100ByOrderByViewedAtDesc();
+    public List<Article> getRecentViewedArticles(Long userId) {
+        if (userId == null) {
+            // exception
+            throw new IllegalArgumentException("유저 정보가 없습니다.");
+        }
+
+        List<ArticleViewHistory> recentViewedHistories = articleViewHistoryJpaRepository.findTop100ByUserIdOrderByViewedAtDesc(userId);
         return recentViewedHistories.stream()
                 .map(ArticleViewHistory::getArticle)
                 .distinct()


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?

- close #34 

## 어떻게 해결했나요?
- token값을 decoding하여 userId를 얻고 해당 userId에 해당하는 유저별 조회 기록을 살펴본다.
- 가장 최신에 본 기사 3개를 반환한다.
- 단, 중복 문제는 distinct를 통해 해결해주었다.
