### PR TITLE
기사 조회 API: 이미지, publishedAt 추가

### DIFF
--- a/src/main/java/gyeongdan/article/article/controller/ArticleController.java
+++ b/src/main/java/gyeongdan/article/article/controller/ArticleController.java
@@ -67,8 +67,8 @@ public class ArticleController {
         List<ArticleAllResponse> finalResponse = recentViewedArticles.stream()
             .map(article -> new ArticleAllResponse(
                 article.getId(),
-                article.getTitle(),
-                article.getContent(),
+                article.getSimpleTitle(),
+                article.getSimpleContent(),
                 article.getViewCount(),
                 article.getCategory(),
                 Optional.ofNullable(article.getImageUrl()),

--- a/src/main/java/gyeongdan/article/article/controller/ArticleController.java
+++ b/src/main/java/gyeongdan/article/article/controller/ArticleController.java
@@ -29,7 +29,8 @@ public class ArticleController {
     // 게시글 상세 조회
     // 단, 유저가 보면 조회기록 저장하고, 유저가 아닌 경우 조회수만 증가시키기.
     @GetMapping("/detail")
-    public ResponseEntity<?> getArticle(@RequestParam Long id, @RequestHeader @Nullable String accessToken) { // id : 기사id, access token : 유저의 접근 권한
+    public ResponseEntity<?> getArticle(@RequestParam Long id,
+        @RequestHeader @Nullable String accessToken) { // id : 기사id, access token : 유저의 접근 권한
         Optional<Long> userId = Optional.empty();
         if (accessToken != null && !accessToken.isEmpty()) {
             userId = jwtUtil.getUserId(jwtUtil.resolveToken(accessToken));
@@ -60,13 +61,20 @@ public class ArticleController {
             userId = jwtUtil.getUserId(jwtUtil.resolveToken(accessToken));
         }
 
-
         // 최근 조회한 기사 3개 가져오기
         List<Article> recentViewedArticles = articleService.getRecentViewedArticles(userId.orElse(null));
 
         List<ArticleAllResponse> finalResponse = recentViewedArticles.stream()
-                .map(article -> new ArticleAllResponse(article.getId(), article.getTitle(), article.getContent(), article.getViewCount(), article.getCategory(), article.getCreatedAt()))
-                .collect(Collectors.toList());
+            .map(article -> new ArticleAllResponse(
+                article.getId(),
+                article.getTitle(),
+                article.getContent(),
+                article.getViewCount(),
+                article.getCategory(),
+                Optional.ofNullable(article.getImageUrl()),
+                Optional.ofNullable(article.getPublishedAt())
+            ))
+            .collect(Collectors.toList());
 
         return ResponseEntity.ok(new CommonResponse<>(finalResponse, "가장 최근에 조회한 게시글 3개 조회 성공", true));
     }

--- a/src/main/java/gyeongdan/article/article/controller/ArticleController.java
+++ b/src/main/java/gyeongdan/article/article/controller/ArticleController.java
@@ -72,7 +72,7 @@ public class ArticleController {
                 article.getViewCount(),
                 article.getCategory(),
                 Optional.ofNullable(article.getImageUrl()),
-                Optional.ofNullable(article.getPublishedAt())
+                article.getPublishedAt()
             ))
             .collect(Collectors.toList());
 

--- a/src/main/java/gyeongdan/article/article/domain/Article.java
+++ b/src/main/java/gyeongdan/article/article/domain/Article.java
@@ -35,7 +35,6 @@ public class Article {
     private Boolean isValid;
     private Long viewCount;
     private String category;
-    private Timestamp createdAt;
     @Nullable
     private LocalDateTime publishedAt;
     @Nullable

--- a/src/main/java/gyeongdan/article/article/domain/Article.java
+++ b/src/main/java/gyeongdan/article/article/domain/Article.java
@@ -4,7 +4,6 @@ import gyeongdan.article.related_documents.domain.ArticleRelatedDocuments;
 import gyeongdan.article.view_history.domain.ArticleViewHistory;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,7 +11,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,8 +27,8 @@ public class Article {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String title;
-    private String content;
+    private String simpleTitle;
+    private String simpleContent;
     @Nullable
     private Boolean isValid;
     private Long viewCount;

--- a/src/main/java/gyeongdan/article/article/domain/Article.java
+++ b/src/main/java/gyeongdan/article/article/domain/Article.java
@@ -4,6 +4,8 @@ import gyeongdan.article.related_documents.domain.ArticleRelatedDocuments;
 import gyeongdan.article.view_history.domain.ArticleViewHistory;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,6 +36,10 @@ public class Article {
     private Long viewCount;
     private String category;
     private Timestamp createdAt;
+    @Nullable
+    private LocalDateTime publishedAt;
+    @Nullable
+    private String imageUrl;
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ArticleViewHistory> viewHistories = new ArrayList<>();
@@ -54,6 +60,7 @@ public class Article {
         this.viewHistories.add(viewHistory);
         viewHistory.setArticle(this);
     }
+
     public void removeViewHistory(ArticleViewHistory viewHistory) {
         viewHistories.remove(viewHistory);
         viewHistory.setArticle(null);
@@ -64,6 +71,7 @@ public class Article {
         this.relatedDocuments.add(relatedDocument);
         relatedDocument.setArticle(this);
     }
+
     public void removeRelatedDocument(ArticleRelatedDocuments relatedDocument) {
         relatedDocuments.remove(relatedDocument);
         relatedDocument.setArticle(null);

--- a/src/main/java/gyeongdan/article/article/domain/Article.java
+++ b/src/main/java/gyeongdan/article/article/domain/Article.java
@@ -33,8 +33,10 @@ public class Article {
     private Boolean isValid;
     private Long viewCount;
     private String category;
+    private LocalDateTime createdAt;
     @Nullable
     private LocalDateTime publishedAt;
+
     @Nullable
     private String imageUrl;
 
@@ -43,6 +45,10 @@ public class Article {
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ArticleRelatedDocuments> relatedDocuments;
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt != null ? publishedAt : createdAt;
+    }
 
     // 활용 메서드들
     public boolean isValid() {

--- a/src/main/java/gyeongdan/article/article/dto/ArticleAllResponse.java
+++ b/src/main/java/gyeongdan/article/article/dto/ArticleAllResponse.java
@@ -21,5 +21,5 @@ public class ArticleAllResponse {
     private Long viewCount;
     private String category;
     private Optional<String> imageUrl;
-    private Optional<LocalDateTime> publishedAt;
+    private LocalDateTime publishedAt;
 }

--- a/src/main/java/gyeongdan/article/article/dto/ArticleAllResponse.java
+++ b/src/main/java/gyeongdan/article/article/dto/ArticleAllResponse.java
@@ -1,5 +1,7 @@
 package gyeongdan.article.article.dto;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +20,6 @@ public class ArticleAllResponse {
     private String content;
     private Long viewCount;
     private String category;
-    private Timestamp createdAt;
+    private Optional<String> imageUrl;
+    private Optional<LocalDateTime> publishedAt;
 }

--- a/src/main/java/gyeongdan/article/article/dto/ArticleDetailResponse.java
+++ b/src/main/java/gyeongdan/article/article/dto/ArticleDetailResponse.java
@@ -2,6 +2,7 @@ package gyeongdan.article.article.dto;
 
 import gyeongdan.article.article.domain.Article;
 import gyeongdan.article.related_documents.domain.ArticleRelatedDocuments;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -17,6 +18,8 @@ public class ArticleDetailResponse {
     private Long viewCount;
     private List<ArticleRelatedDocuments> relatedDocuments;
     private Boolean isValid;
+    private Optional<String> imageUrl;
+    private Optional<String> publishedAt;
 
     public ArticleDetailResponse(Article article) {
         this.id = article.getId();
@@ -25,5 +28,7 @@ public class ArticleDetailResponse {
         this.viewCount = article.getViewCount();
         this.relatedDocuments = article.getRelatedDocuments();
         this.isValid = article.isValid();
+        this.imageUrl = Optional.ofNullable(article.getImageUrl());
+        this.publishedAt = Optional.ofNullable(article.getPublishedAt()).map(Object::toString);
     }
 }

--- a/src/main/java/gyeongdan/article/article/dto/ArticleDetailResponse.java
+++ b/src/main/java/gyeongdan/article/article/dto/ArticleDetailResponse.java
@@ -23,8 +23,8 @@ public class ArticleDetailResponse {
 
     public ArticleDetailResponse(Article article) {
         this.id = article.getId();
-        this.title = article.getTitle();
-        this.content = article.getContent();
+        this.title = article.getSimpleTitle();
+        this.content = article.getSimpleContent();
         this.viewCount = article.getViewCount();
         this.relatedDocuments = article.getRelatedDocuments();
         this.isValid = article.isValid();

--- a/src/main/java/gyeongdan/article/article/service/ArticleService.java
+++ b/src/main/java/gyeongdan/article/article/service/ArticleService.java
@@ -69,9 +69,17 @@ public class ArticleService {
     public List<ArticleAllResponse> getValidArticles() {
         List<Article> articles = articleRepository.findAll();
         return articles.stream()
-                .filter(Article::isValid)
-                .map(article -> new ArticleAllResponse(article.getId(), article.getTitle(), article.getContent(), article.getViewCount(), article.getCategory(), article.getCreatedAt()))
-                .collect(Collectors.toList());
+            .filter(Article::isValid)
+            .map(article -> new ArticleAllResponse(
+                article.getId(),
+                article.getTitle(),
+                article.getContent(),
+                article.getViewCount(),
+                article.getCategory(),
+                Optional.ofNullable(article.getImageUrl()),
+                Optional.ofNullable(article.getPublishedAt())
+            ))
+            .collect(Collectors.toList());
     }
 
     // 조회수 증가 메서드
@@ -89,12 +97,13 @@ public class ArticleService {
     public List<Article> getRecentViewedArticles(Long userId) {
         userManageService.checkUserExist(userId);
 
-        List<ArticleViewHistory> recentViewedHistories = articleViewHistoryJpaRepository.findTop100ByUserIdOrderByViewedAtDesc(userId);
+        List<ArticleViewHistory> recentViewedHistories = articleViewHistoryJpaRepository.findTop100ByUserIdOrderByViewedAtDesc(
+            userId);
         return recentViewedHistories.stream()
-                .map(ArticleViewHistory::getArticle)
-                .distinct()
-                .limit(3)
-                .collect(Collectors.toList());
+            .map(ArticleViewHistory::getArticle)
+            .distinct()
+            .limit(3)
+            .collect(Collectors.toList());
     }
 
     // 오늘 가장 인기 있는 기사 5개 가져오는 메서드 (조회수 기준)
@@ -106,7 +115,7 @@ public class ArticleService {
         List<Article> articles = articleViewHistoryJpaRepository.findTopArticlesByViewedAtBetween(startOfDay, endOfDay);
 
         return articles.stream()
-                .map(article -> new PopularArticleResponse(article.getId(), article.getTitle(), article.getViewCount()))
-                .collect(Collectors.toList());
+            .map(article -> new PopularArticleResponse(article.getId(), article.getTitle(), article.getViewCount()))
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/gyeongdan/article/article/service/ArticleService.java
+++ b/src/main/java/gyeongdan/article/article/service/ArticleService.java
@@ -76,7 +76,7 @@ public class ArticleService {
                 article.getViewCount(),
                 article.getCategory(),
                 Optional.ofNullable(article.getImageUrl()),
-                Optional.ofNullable(article.getPublishedAt())
+                article.getPublishedAt()
             ))
             .collect(Collectors.toList());
     }

--- a/src/main/java/gyeongdan/article/article/service/ArticleService.java
+++ b/src/main/java/gyeongdan/article/article/service/ArticleService.java
@@ -5,7 +5,6 @@ import gyeongdan.article.view_history.domain.ArticleViewHistory;
 import gyeongdan.article.article.dto.ArticleAllResponse;
 import gyeongdan.article.article.dto.ArticleUpdateRequest;
 import gyeongdan.article.article.dto.PopularArticleResponse;
-import gyeongdan.article.article.repository.ArticleJpaRepository;
 import gyeongdan.article.article.repository.ArticleRepository;
 
 import java.time.LocalDate;
@@ -60,8 +59,8 @@ public class ArticleService {
 
     public Long updateArticle(ArticleUpdateRequest articleUpdateRequest) {
         Article article = articleRepository.findById(articleUpdateRequest.getId());
-        article.setTitle(articleUpdateRequest.getTitle());
-        article.setContent(articleUpdateRequest.getContent());
+        article.setSimpleTitle(articleUpdateRequest.getTitle());
+        article.setSimpleContent(articleUpdateRequest.getContent());
         return articleRepository.save(article).getId();
     }
 
@@ -72,8 +71,8 @@ public class ArticleService {
             .filter(Article::isValid)
             .map(article -> new ArticleAllResponse(
                 article.getId(),
-                article.getTitle(),
-                article.getContent(),
+                article.getSimpleTitle(),
+                article.getSimpleContent(),
                 article.getViewCount(),
                 article.getCategory(),
                 Optional.ofNullable(article.getImageUrl()),
@@ -115,7 +114,7 @@ public class ArticleService {
         List<Article> articles = articleViewHistoryJpaRepository.findTopArticlesByViewedAtBetween(startOfDay, endOfDay);
 
         return articles.stream()
-            .map(article -> new PopularArticleResponse(article.getId(), article.getTitle(), article.getViewCount()))
+            .map(article -> new PopularArticleResponse(article.getId(), article.getSimpleTitle(), article.getViewCount()))
             .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?

- close #41 

## 어떻게 해결했나요?
- 기사 조회할 때, imageUrl을 가져오고 있지 않아 가져오도록 수정했습니다.
- createdAt이 아닌 publisehdAt을 반환하도록 수정했습니다.
- 그러나 만약에 publisehdAt가 비었다면 createdAt을 대신 보냅니다

클라이언트에서 createdAt & publishedAt 두가지중 하나로 통일시켜달라고 하여, 엄연히 따지면 publishedAt이 맞다고 판단하여 publishedAt으로 통일했습니다. 
